### PR TITLE
changed `tabler-icons` package to `@tabler/icons`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "rickshaw": "1.7.1",
-    "tabler-icons": "^1.10.0"
+    "@tabler/icons": "^1.35.0"
   },
   "devDependencies": {
     "@babel/core": "7.10.4",


### PR DESCRIPTION
Hi! We moved `tabler-icons` package to `@tabler` scope in npm. Old package will be deprecated soon. 

Thank you for your work! :) 